### PR TITLE
Expose require file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 master
 ------
 
+* Introduce `ember-cli-rails-deploy-redis` for the sake of requiring from the
+  `gem` invocation in the `Gemfile`.
+
 0.1.0
 -----
 

--- a/lib/ember-cli-rails-deploy-redis.rb
+++ b/lib/ember-cli-rails-deploy-redis.rb
@@ -1,0 +1,1 @@
+require "ember_cli/deploy/redis"


### PR DESCRIPTION
Introduce `ember-cli-rails-deploy-redis` for the sake of requiring from
the `gem` invocation in the `Gemfile`.
