### PR TITLE
Add `#mountable?` and `#to_rack` to deploy API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 master
 ------
 
+* Add `#mountable?` and `#to_rack` to deploy API.
+
 0.1.1
 -----
 

--- a/lib/ember_cli/deploy/redis.rb
+++ b/lib/ember_cli/deploy/redis.rb
@@ -12,6 +12,14 @@ module EmberCli
         redis_client.get(deploy_key).presence || index_html_missing!
       end
 
+      def mountable?
+        false
+      end
+
+      def to_rack
+        raise NotImplementedError
+      end
+
       private
 
       attr_reader :app

--- a/spec/lib/ember_cli/deploy/redis_spec.rb
+++ b/spec/lib/ember_cli/deploy/redis_spec.rb
@@ -2,6 +2,24 @@ require "spec_helper"
 require "ember_cli/deploy/redis"
 
 describe EmberCli::Deploy::Redis do
+  describe "#mountable?" do
+    it "returns false" do
+      ember_cli_deploy = build_ember_cli_deploy
+
+      mountable = ember_cli_deploy.mountable?
+
+      expect(mountable).to be false
+    end
+  end
+
+  describe "#to_rack" do
+    it "raises a NotImplementedError" do
+      ember_cli_deploy = build_ember_cli_deploy
+
+      expect { ember_cli_deploy.to_rack }.to raise_error(NotImplementedError)
+    end
+  end
+
   describe "#index_html" do
     context "when the keys are present" do
       it "retrieves the HTML from Redis" do


### PR DESCRIPTION
`ember-cli-rails`'s deploy process [now determines if a deploy strategy
needs to be mounted as a routable rack app](https://github.com/thoughtbot/ember-cli-rails/pull/386).

This deployment strategy doesn't, but it still needs to quack like other
strategies.
